### PR TITLE
filter in binding

### DIFF
--- a/app/App.view.xml
+++ b/app/App.view.xml
@@ -1,7 +1,7 @@
 <mvc:View displayBlock="true" xmlns="sap.m" xmlns:mvc="sap.ui.core.mvc">
   <App>
     <Page title="Northwind Data">
-      <List items="{path: '/Products'}" growing="true">
+      <List items="{path: '/Products', parameters: { $filter: 'Discontinued eq true' } }" growing="true">
         <ObjectListItem title="{ProductName}" markFlagged="true">
           <ObjectAttribute text="{QuantityPerUnit}" />
           <markers>

--- a/app/App.view.xml
+++ b/app/App.view.xml
@@ -2,7 +2,12 @@
   <App>
     <Page title="Northwind Data">
       <List items="{path: '/Products'}" growing="true">
-        <StandardListItem title="{ProductName}" description="{QuantityPerUnit}" />
+        <ObjectListItem title="{ProductName}" markFlagged="true">
+          <ObjectAttribute text="{QuantityPerUnit}" />
+          <markers>
+            <ObjectMarker type="Flagged" visible="{Discontinued}" />
+          </markers>
+        </ObjectListItem>
       </List>
     </Page>
   </App>


### PR DESCRIPTION
Addressing #5, here is an example of how to influence what data is returned, by adding system query parameters to the binding info.

You can add these system query parameters to the binding info, directly in the aggregation binding expression. See this [Filtering](https://sapui5.hana.ondemand.com/sdk/#/topic/5338bd1f9afb45fb8b2af957c3530e8f.html) section for more information. 

To demonstrated, I decided to use the `Discontinued` boolean property of the `Products` entity type. In this branch I replaced the `StandardListItem` with an `ObjectListItem` control so I could use an `ObjectMarker` to identify discontinued products with a flag, and then extended the binding info to add a `$filter` system query parameter value (`Discontinued eq true`). Change this to `Discontinued eq false` to see the effect for yourself, for example).

In other words, the simplest binding value for the `items` aggregation would be something like this:

```
{/Products}
```

But additional information can be supplied if this binding value is extended to an object, like this:

```
{
  path: '/Products',
  parameters: {
    $filter: 'Discontinued eq true'
  }
}
```

Here's a part of the list display with the filter applied:

<img width="761" alt="screenshot 2022-05-26 at 08 16 25" src="https://user-images.githubusercontent.com/73068/170437898-fe6ff016-6d78-4fe1-bdd1-1c01eef6bdb8.png">


We can take a brief look at this in [episode 3, on Fri 27 May](https://www.youtube.com/watch?v=Bln2A0_OauY).